### PR TITLE
Add gz-jetty-cmake alias package

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -22,3 +22,11 @@ Description: Gazebo CMake Library - Development files
  third party projects against them. It provides modules that are used to find
  dependencies of Gazebo projects and generate cmake targets for consumers of
  Gazebo projects to link against.
+
+Package: gz-jetty-cmake
+Depends: libgz-cmake5-dev (= ${binary:Version}), ${misc:Depends}
+Architecture: all
+Priority: optional
+Section: metapackages
+Description: alias package
+ Provides a package for Jetty without exposing the version number.


### PR DESCRIPTION
Adds a `gz-jetty-cmake` package that depends on
`libgz-cmake5-dev` to allow installing Jetty packages without knowing the version number.

Prototype of https://github.com/gazebo-tooling/release-tools/issues/1326.

testing:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz-cmake5-debbuilder&build=147)](https://build.osrfoundation.org/job/gz-cmake5-debbuilder/147/) https://build.osrfoundation.org/job/gz-cmake5-debbuilder/147/