### PR TITLE
Add new libgz jetty aliases

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -30,3 +30,12 @@ Priority: optional
 Section: metapackages
 Description: alias package
  Provides a package for Jetty without exposing the version number.
+
+Package: libgz-jetty-cmake-dev
+Depends: libgz-cmake5-dev (= ${binary:Version}), ${misc:Depends}
+Architecture: all
+Priority: optional
+Section: metapackages
+Description: alias package
+ Provides a package for Jetty without exposing the version number.
+


### PR DESCRIPTION
Added the same kind of aliases than the ones used for rotary. See
https://github.com/gazebo-tooling/release-tools/issues/1446